### PR TITLE
Elias fixes

### DIFF
--- a/models/imputation/__init__.py
+++ b/models/imputation/__init__.py
@@ -77,7 +77,7 @@ async def train_validate_predict(req: TrainRequest):
     else:
         manual_predictors = req.number_predictor
 
-    avg_rmse, rmse, model_feature_importance, model_feature_names, prediction = \
+    avg_rmse, rmse, model_feature_importance, model_feature_names, prediction,correlation = \
         query_and_train(manual_predictors, req.target_year,
                         req.target,
                         req.interpolator,
@@ -86,4 +86,4 @@ async def train_validate_predict(req: TrainRequest):
                         req.model,
                         req.interval, None)
     logger.info("Return values %f %f", rmse, avg_rmse)
-    return ModelResponse(rmse_deviation=avg_rmse, rmse=rmse, model_feature_importance=model_feature_importance, model_feature_names=model_feature_names, prediction=prediction)
+    return ModelResponse(rmse_deviation=avg_rmse, rmse=rmse, model_feature_importance=model_feature_importance, model_feature_names=model_feature_names, prediction=prediction,correlation=correlation)

--- a/models/imputation/__init__.py
+++ b/models/imputation/__init__.py
@@ -77,7 +77,7 @@ async def train_validate_predict(req: TrainRequest):
     else:
         manual_predictors = req.number_predictor
 
-    avg_rmse, rmse, model_feature_importance, model_feature_names, prediction,correlation = \
+    avg_rmse, rmse, model_feature_importance, model_feature_names, prediction,correlation,feature_importance_pie = \
         query_and_train(manual_predictors, req.target_year,
                         req.target,
                         req.interpolator,
@@ -86,4 +86,4 @@ async def train_validate_predict(req: TrainRequest):
                         req.model,
                         req.interval, None)
     logger.info("Return values %f %f", rmse, avg_rmse)
-    return ModelResponse(rmse_deviation=avg_rmse, rmse=rmse, model_feature_importance=model_feature_importance, model_feature_names=model_feature_names, prediction=prediction,correlation=correlation)
+    return ModelResponse(rmse_deviation=avg_rmse, rmse=rmse, model_feature_importance=model_feature_importance, model_feature_names=model_feature_names, prediction=prediction,correlation=correlation,feature_importance_pie=feature_importance_pie)

--- a/models/imputation/definitions.py
+++ b/models/imputation/definitions.py
@@ -65,3 +65,4 @@ class ModelResponse(BaseModel):
     model_feature_names: Optional[List[str]]
     prediction: Optional[dict]
     correlation: Optional[dict]
+    feature_importance_pie: Optional[dict]

--- a/models/imputation/definitions.py
+++ b/models/imputation/definitions.py
@@ -64,3 +64,4 @@ class ModelResponse(BaseModel):
     model_feature_importance: Optional[List[float]]
     model_feature_names: Optional[List[str]]
     prediction: Optional[dict]
+    correlation: Optional[dict]

--- a/models/imputation/model.py
+++ b/models/imputation/model.py
@@ -4,8 +4,7 @@ import os
 
 import numpy as np
 import pandas as pd
-# Country name format
-import pycountry
+
 # Propcessing and training
 from fastapi import HTTPException
 from sklearn.decomposition import PCA
@@ -384,8 +383,7 @@ def model_trainer(X_train, X_test, y_train, seed, n_estimators, model_type, inte
 
     # Predict for SIDS countries with missing values
     prediction = prediction[prediction.index.isin(SIDS)]
-    prediction.index = [pycountry.countries.get(alpha_3=i).name for i in prediction.index]
-    prediction = prediction.reset_index().rename(columns={"index": "country"})
+    prediction = prediction.reset_index().rename(columns={"index": "country"}).to_dict(orient='list')
     #################### Prediction dataframe and best_model instance are the final results of the ML################
 
     return prediction, rmse, gs, best_model

--- a/models/imputation/model.py
+++ b/models/imputation/model.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 # Propcessing and training
 from fastapi import HTTPException
-from sklearn.decomposition import PCA
+from pca import pca
 from sklearn.ensemble import ExtraTreesRegressor, RandomForestRegressor, GradientBoostingRegressor
 from sklearn.experimental import enable_iterative_imputer  # noqa
 from sklearn.feature_selection import RFE
@@ -240,30 +240,21 @@ def feature_selection(X_train, X_test, y_train, target, manual_predictors, schem
         # Take the most import predictor_number number of independent variables (via RFE) and plot correlation
         importance_boolean = feature_selector(X_train=X_train, y_train=y_train, manual_predictors=manual_predictors)
         prediction_features = (X_train.columns[importance_boolean].tolist())
-        # query_card = correlation_plotter(target,prediction_features, training_data, ind_meta)
-        X_train = X_train[prediction_features]
-        X_test = X_test[prediction_features]
+
 
     elif scheme == Schema.PCA:
-        pca = PCA(n_components=manual_predictors)
-        pca.fit(X_train)
-        columns = ["pca " + str(i) for i in list(range(manual_predictors))]
-        X_train = pd.DataFrame(pca.transform(X_train), columns=columns, index=X_train.index)
-        X_test = pd.DataFrame(pca.transform(X_test), columns=columns, index=X_test.index)
-        #### Temporary ####
-        # correlation= X_train.copy()
-        # correlation[ind_meta[ind_meta["Indicator Code"]==target].Indicator.values[0]] = y_train.values
-        # query_card = px.imshow(correlation.corr(),x=correlation.columns,y=correlation.columns, color_continuous_scale=px.colors.sequential.Blues, title= 'Correlation plot')
-
-
+        PCA = pca()
+        out = PCA.fit_transform(X_train)
+        prediction_features = list(out['topfeat'].iloc[list(range(manual_predictors)),1].values)
 
     else:
         prediction_features = manual_predictors
-        # query_card = correlation_plotter(target,prediction_features, training_data, ind_meta)
-        X_train = X_train[prediction_features]
-        X_test = X_test[prediction_features]
 
-    return X_train, X_test  # ,query_card
+
+    X_train = X_train[prediction_features]
+    X_test = X_test[prediction_features]
+
+    return X_train, X_test  
 
 
 # Train model and predict

--- a/models/imputation/model.py
+++ b/models/imputation/model.py
@@ -542,6 +542,10 @@ def query_and_train(manual_predictors, target_year, target, interpolator, scheme
     logging.info('Feature selection completed')
     # training and prediction for X_test
     prediction, rmse, gs, best_model = model_trainer(X_train, X_test, y_train, seed, estimators, model, interval)
+    
+    # data for pie chart for feature importance 
+    features = indicatorMeta[indicatorMeta["Indicator Code"].isin(X_train.columns)]
+    feature_importance_pie =pd.DataFrame(data={"category":features.Category.values,"value":best_model.feature_importances_}).groupby("category").sum().reset_index().to_dict(orient="list")
 
     return (
-                   rmse / y_train.mean()).item(), rmse.item(), best_model.feature_importances_.tolist(), best_model.feature_names_in_.tolist(), prediction,correlation
+                   rmse / y_train.mean()).item(), rmse.item(), best_model.feature_importances_.tolist(), best_model.feature_names_in_.tolist(), prediction,correlation,feature_importance_pie

--- a/models/imputation/model.py
+++ b/models/imputation/model.py
@@ -233,7 +233,7 @@ def feature_selection(X_train, X_test, y_train, target, manual_predictors, schem
     Returns:
         X_train: reduced training data
         X_test: reduced testing data
-        query_card: correlation plot of X_train (ignore for now)
+        correlation: correlation matrix of X_train (ignore for now)
     """
 
     if scheme == Schema.AFS:
@@ -254,7 +254,11 @@ def feature_selection(X_train, X_test, y_train, target, manual_predictors, schem
     X_train = X_train[prediction_features]
     X_test = X_test[prediction_features]
 
-    return X_train, X_test  
+    correlation = X_train[prediction_features].corr()
+    correlation.index = prediction_features
+    correlation.columns = prediction_features
+
+    return X_train, X_test,correlation.to_dict(orient ='split')
 
 
 # Train model and predict
@@ -533,11 +537,11 @@ def query_and_train(manual_predictors, target_year, target, interpolator, scheme
 
     logging.info('Data preprocessed')
     # Dimension reduction based on scheme
-    X_train, X_test = feature_selection(X_train, X_test, y_train, target, manual_predictors, scheme)
+    X_train, X_test,correlation = feature_selection(X_train, X_test, y_train, target, manual_predictors, scheme)
 
     logging.info('Feature selection completed')
     # training and prediction for X_test
     prediction, rmse, gs, best_model = model_trainer(X_train, X_test, y_train, seed, estimators, model, interval)
 
     return (
-                   rmse / y_train.mean()).item(), rmse.item(), best_model.feature_importances_.tolist(), best_model.feature_names_in_.tolist(), prediction
+                   rmse / y_train.mean()).item(), rmse.item(), best_model.feature_importances_.tolist(), best_model.feature_names_in_.tolist(), prediction,correlation

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ fastapi~=0.75.0
 scikit-learn==1.0.2
 numpy
 pandas
+pca
 python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ fastapi~=0.75.0
 scikit-learn==1.0.2
 numpy
 pandas
-pycountry
 python-multipart


### PR DESCRIPTION

update prediction dataframe
the prediction return from the model trainer function changed from dataframe to dict with list orientation. pycountry package no longer used so removed from model and requirements file

update PCA
With the update, when the PCA scheme is chosen for feature selection, instead of principal components, features with largest loadings on prinicpal components are used as prediction_featues. A new package is used in this update so the requirments file is also changed.

update correlation matrix
Generate a correlation matrix in the feature_selection function and have it returned in the response. Generation happens in model.py with updates to ModelResponse in definitions.py and __init.py__


add pie chart data
Generate a the data for pie chart  in the query_and_train function and have it returned in the response. Generation happens in model.py with updates to ModelResponse in definitions.py and __init.py__